### PR TITLE
Add tests for ORMD parser

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,2 @@
+nodeLinker: node-modules
+enableImmutableInstalls: false

--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
   "scripts": {
     "dev": "echo 'Development server not yet implemented'",
     "build": "echo 'Build process not yet implemented'",
-    "test": "echo 'Tests not yet implemented'",
+    "test": "node ./scripts/run-tests.js",
     "setup:rocketchat": "cd Rocket.Chat && yarn install",
     "start:mongo": "cd Rocket.Chat && docker compose -f docker-compose-local.yml up -d mongo",
     "stop:mongo": "cd Rocket.Chat && docker compose -f docker-compose-local.yml down"
   },
   "keywords": [
     "ai",
-    "collaboration", 
+    "collaboration",
     "knowledge-management",
     "relational-intelligence",
     "ormd",

--- a/packages/ormd-parser/jest.config.js
+++ b/packages/ormd-parser/jest.config.js
@@ -1,0 +1,11 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json', 'node'],
+  transform: {
+    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.json' }]
+  },
+  testMatch: ['**/__tests__/**/*.test.ts']
+};

--- a/packages/ormd-parser/src/__tests__/parser.test.ts
+++ b/packages/ormd-parser/src/__tests__/parser.test.ts
@@ -1,0 +1,72 @@
+import { ORMDParser } from '../parser';
+
+describe('ORMDParser', () => {
+  const validOrmDocument = `<!-- ormd:0.1 -->\n---\n` +
+    `title: Decision Record\n` +
+    `dates:\n` +
+    `  created: '2024-02-01T09:30:00Z'\n` +
+    `  modified: '2024-02-10T11:00:00Z'\n` +
+    `context:\n` +
+    `  resolution:\n` +
+    `    confidence: validated\n` +
+    `    evidence_strength: strong\n` +
+    `  lineage:\n` +
+    `    source: synthesis-pipeline\n` +
+    `status: active\n` +
+    `version: '2.0'\n` +
+    `description: Example ORMD snippet inspired by platform documentation.\n` +
+    `---\n\n` +
+    `# Decision Context\n\n` +
+    `Documented resolution and supporting metadata.`;
+
+  it('parses, validates, and converts a valid ORMD document', () => {
+    const parseResult = ORMDParser.parse(validOrmDocument);
+
+    expect(parseResult.success).toBe(true);
+    expect(parseResult.data).toBeDefined();
+    expect(parseResult?.warnings).toBeUndefined();
+
+    const document = parseResult.data!;
+    expect(document.frontmatter.title).toBe('Decision Record');
+
+    const validation = ORMDParser.validate(document);
+    expect(validation.valid).toBe(true);
+    expect(validation.errors).toBeUndefined();
+
+    const bundle = ORMDParser.toContextBundle(document, 'urn:cb:TESTBUNDLE');
+    expect(bundle.id).toBe('urn:cb:TESTBUNDLE');
+    expect(bundle.version).toBe('2.0');
+    expect(bundle.created).toBe('2024-02-01T09:30:00Z');
+    expect(bundle.content.data).toBe(validOrmDocument);
+    expect(bundle.frame.type).toBe('ormd.document');
+    expect(bundle.resolution.confidence).toBe('validated');
+    expect(bundle.resolution.evidence_strength).toBe('strong');
+  });
+
+  it('fails to parse content without ORMD frontmatter', () => {
+    const noFrontmatter = `<!-- ormd:0.1 -->\n` +
+      `# Untitled\n\n` +
+      `This content omits the required YAML block.`;
+
+    const parseResult = ORMDParser.parse(noFrontmatter);
+
+    expect(parseResult.success).toBe(false);
+    expect(parseResult.errors).toContain('Invalid ORMD format: missing YAML frontmatter');
+  });
+
+  it('emits a warning when the ORMD version comment is missing', () => {
+    const missingComment = `---\n` +
+      `title: Missing Comment Example\n` +
+      `dates:\n` +
+      `  created: '2024-01-15T10:00:00Z'\n` +
+      `---\n\n` +
+      `Content still follows the schema.`;
+
+    const parseResult = ORMDParser.parse(missingComment);
+
+    expect(parseResult.success).toBe(true);
+    expect(parseResult.warnings).toEqual([
+      'Missing ORMD version comment (<!-- ormd:0.1 -->)'
+    ]);
+  });
+});

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const [, , ...args] = process.argv;
+
+if (args.length === 0) {
+  console.error('Please provide a workspace name, e.g. "yarn test ormd-parser".');
+  process.exit(1);
+}
+
+const [target, ...forwarded] = args;
+const workspace = target.startsWith('@') ? target : `@nexes/${target}`;
+
+const run = (command, commandArgs) =>
+  spawnSync(command, commandArgs, {
+    stdio: 'inherit',
+    env: process.env
+  });
+
+const result = run('yarn', ['workspace', workspace, 'test', ...forwarded]);
+
+if (result.status === 0) {
+  process.exit(0);
+}
+
+if (workspace === '@nexes/ormd-parser') {
+  console.warn(
+    'Falling back to direct Jest execution for @nexes/ormd-parser (Yarn workspace command was unavailable).'
+  );
+  const configPath = path.join('packages', 'ormd-parser', 'jest.config.js');
+  const fallback = run('npx', ['jest', '--config', configPath, ...forwarded]);
+  process.exit(fallback.status ?? 1);
+}
+
+process.exit(typeof result.status === 'number' ? result.status : 1);


### PR DESCRIPTION
## Summary
- add a ts-jest powered configuration for the ORMD parser package and cover key parse scenarios with unit tests
- update the root test runner to delegate to the ORMD parser suite (with a fallback when Yarn workspaces are unavailable)

## Testing
- node scripts/run-tests.js ormd-parser

------
https://chatgpt.com/codex/tasks/task_e_68dc09bfb89083338c586a954bb728b1