### PR TITLE
feat(chat): expose handoff reason enum

### DIFF
--- a/packages/chat-interface/src/chat-manager.ts
+++ b/packages/chat-interface/src/chat-manager.ts
@@ -5,7 +5,7 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import { ContextStorage } from '@nexes/context-storage';
-import { HandoffManager, HandoffAgent } from '@nexes/ai-handoff';
+import { HandoffManager, HandoffAgent, HandoffDocument } from '@nexes/ai-handoff';
 import { ORMDParser } from '@nexes/ormd-parser';
 
 export interface ChatMessage {
@@ -139,7 +139,11 @@ export class ChatManager {
   /**
    * Create handoff from current chat session
    */
-  async createChatHandoff(toAgent?: HandoffAgent, reason: string = 'Chat session handoff'): Promise<string> {
+  async createChatHandoff(
+    toAgent?: HandoffAgent,
+    reason: string = 'Chat session handoff',
+    handoffReason: HandoffDocument['frontmatter']['handoff']['handoff_reason'] = 'agent_switch'
+  ): Promise<string> {
     if (!this.currentSession?.handoff_session_id) {
       throw new Error('No active handoff session');
     }
@@ -168,7 +172,7 @@ export class ChatManager {
       ]
     });
 
-    const handoffId = await this.handoffManager.createHandoff(toAgent, 'agent_switch');
+    const handoffId = await this.handoffManager.createHandoff(toAgent, handoffReason);
 
     // Add handoff message to chat
     await this.addMessage({

--- a/packages/chat-interface/src/cli.ts
+++ b/packages/chat-interface/src/cli.ts
@@ -161,11 +161,15 @@ class ChatCLI {
 
   private async createHandoff() {
     try {
+      const displayReason = 'Manual handoff requested by user';
+      const handoffReason = 'agent_switch' as const;
+
       const handoffId = await this.chatManager.createChatHandoff(
-        undefined, 
-        'Manual handoff requested by user'
+        undefined,
+        displayReason,
+        handoffReason
       );
-      
+
       console.log(`✅ Handoff created successfully!`);
       console.log(`📄 Handoff ID: ${handoffId.substring(0, 16)}`);
       console.log(`🔍 This handoff contains full context of the conversation.`);


### PR DESCRIPTION
## Summary
- allow the chat manager handoff helper to accept a typed handoff reason while keeping the display message
- forward the enum reason through to the handoff manager implementation
- update the CLI handoff command to supply both the user-facing message and enum reason

## Testing
- npm run build:ormd
- npm run build:storage
- npm run build:handoff
- npm run build:chat
- printf "/quit\n" | node packages/chat-interface/dist/cli.js


------
https://chatgpt.com/codex/tasks/task_e_68dc1a0cfe488333824d6843496150d8