### PR TITLE
Add Jest tests for AI handoff lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ npm run build:all
 
 # Test ORMD parser
 npm run test:ormd
+
+# Run AI handoff tests
+npm test --workspace @nexes/ai-handoff
 ```
 
 **Using yarn (if you have yarn 4.0+):**

--- a/package-lock.json
+++ b/package-lock.json
@@ -4960,8 +4960,11 @@
         "uuid": "^9.0.1"
       },
       "devDependencies": {
+        "@types/jest": "^29.0.0",
         "@types/node": "^20.0.0",
         "@types/uuid": "^9.0.7",
+        "jest": "^29.0.0",
+        "ts-jest": "^29.0.0",
         "typescript": "^5.0.0"
       }
     },

--- a/packages/ai-handoff/jest.config.js
+++ b/packages/ai-handoff/jest.config.js
@@ -1,0 +1,15 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json', 'node'],
+  transform: {
+    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.json' }]
+  },
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  moduleNameMapper: {
+    '^@nexes/ormd-parser$': '<rootDir>/../ormd-parser/src',
+    '^@nexes/context-storage$': '<rootDir>/../context-storage/src'
+  }
+};

--- a/packages/ai-handoff/package.json
+++ b/packages/ai-handoff/package.json
@@ -27,6 +27,9 @@
   "devDependencies": {
     "@types/uuid": "^9.0.7",
     "@types/node": "^20.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "@types/jest": "^29.0.0"
   }
 }

--- a/packages/ai-handoff/src/__tests__/handoff-manager.test.ts
+++ b/packages/ai-handoff/src/__tests__/handoff-manager.test.ts
@@ -1,0 +1,78 @@
+import { HandoffManager } from '../handoff-manager';
+import { HandoffAgent } from '../types';
+
+describe('HandoffManager', () => {
+  class InMemoryContextStorage {
+    private bundles = new Map<string, any>();
+
+    async store(bundle: any): Promise<any> {
+      const stored = {
+        ...bundle,
+        _id: bundle.id,
+        indexed_at: new Date().toISOString(),
+        search_text: '',
+        tags: []
+      };
+
+      this.bundles.set(bundle.id, stored);
+      return stored;
+    }
+
+    async get(id: string): Promise<any | null> {
+      return this.bundles.get(id) ?? null;
+    }
+
+    getStored(id: string): any | undefined {
+      return this.bundles.get(id);
+    }
+  }
+
+  const createAgent = (id: string, display: string): HandoffAgent => ({
+    id,
+    display,
+    type: 'ai'
+  });
+
+  it('preserves context through handoff lifecycle', async () => {
+    const storage = new InMemoryContextStorage();
+    const manager = new HandoffManager(storage as unknown as any);
+
+    const primaryAgent = createAgent('agent-primary', 'Primary Agent');
+    const followupAgent = createAgent('agent-followup', 'Follow-up Agent');
+
+    const session = await manager.startSession(primaryAgent);
+    expect(session.context.session_id).toBeDefined();
+
+    manager.updateContext({
+      summary: 'Coordinate multi-agent collaboration',
+      recommended_next_steps: ['Review shared context bundle'],
+      context_notes: 'Ensure JSON context remains attached to markdown.'
+    });
+
+    expect(manager.getCurrentSession()?.context.summary).toBe('Coordinate multi-agent collaboration');
+
+    const handoffId = await manager.createHandoff(followupAgent, 'agent_switch');
+    expect(manager.getCurrentSession()?.status).toBe('completed');
+
+    const storedBundle = storage.getStored(handoffId);
+    expect(storedBundle).toBeDefined();
+    expect(storedBundle?.content.type).toBe('text/markdown');
+
+    const rawContent = storedBundle!.content.data;
+    expect(rawContent).toContain('<!-- HANDOFF_CONTEXT -->');
+
+    const embeddedJson = rawContent
+      .split('<!-- HANDOFF_CONTEXT -->')[1]
+      .split('<!-- /HANDOFF_CONTEXT -->')[0]
+      .trim();
+
+    const parsedContext = JSON.parse(embeddedJson);
+    expect(parsedContext.summary).toBe('Coordinate multi-agent collaboration');
+    expect(parsedContext.recommended_next_steps).toContain('Review shared context bundle');
+    expect(parsedContext.context_notes).toContain('Ensure JSON context remains attached');
+
+    const loaded = await manager.loadHandoff(handoffId);
+    expect(loaded.handoff_context.summary).toBe('Coordinate multi-agent collaboration');
+    expect(loaded.frontmatter.handoff.to_agent).toBe(followupAgent.id);
+  });
+});

--- a/packages/ai-handoff/src/handoff-manager.ts
+++ b/packages/ai-handoff/src/handoff-manager.ts
@@ -258,7 +258,7 @@ export class HandoffManager {
     }
 
     const results = await this.storage.query(searchQuery);
-    return results.bundles.map(bundle => bundle.id);
+    return results.bundles.map((bundle: any) => bundle.id);
   }
 
   /**

--- a/packages/ai-handoff/tsconfig.json
+++ b/packages/ai-handoff/tsconfig.json
@@ -12,7 +12,12 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "paths": {
+      "@nexes/ormd-parser": ["../ormd-parser/src"],
+      "@nexes/context-storage": ["../context-storage/src"]
+    }
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
## Summary
- configure Jest for the AI handoff package with ts-jest and workspace module mappings
- add a lifecycle test that exercises session updates, handoff creation, and loading with an in-memory storage stub
- document how to run the AI handoff test suite from the project README

## Testing
- npm test --workspace @nexes/ai-handoff

------
https://chatgpt.com/codex/tasks/task_e_68dc1b5b8eac83338d941d20b48aa552